### PR TITLE
add terraform for ECRs

### DIFF
--- a/terraform/dashboard_ecr.tf
+++ b/terraform/dashboard_ecr.tf
@@ -1,0 +1,31 @@
+resource "aws_ecr_repository" "c14_earthquake_monitor_dashboard_ecr" {
+  name                 = "c14_earthquake_monitor_dashboard_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "c14_earthquake_monitor_dashboard_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_earthquake_monitor_dashboard_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/data_upload_ecr.tf
+++ b/terraform/data_upload_ecr.tf
@@ -1,0 +1,31 @@
+resource "aws_ecr_repository" "c14_earthquake_monitor_data_upload_ecr" {
+  name                 = "c14_earthquake_monitor_data_upload_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "c14_earthquake_monitor_data_upload_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_earthquake_monitor_data_upload_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/etl_pipeline_ecr.tf
+++ b/terraform/etl_pipeline_ecr.tf
@@ -1,0 +1,31 @@
+resource "aws_ecr_repository" "c14_earthquake_monitor_etl_ecr" {
+  name                 = "c14_earthquake_monitor_etl_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "c14_earthquake_monitor_etl_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_earthquake_monitor_etl_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
Closes #20 

Created 3 new files in `terraform` folder:
- `etl_pipeline_ecr.tf`
- `data_upload_ecr.tf`
- `dashboard_ecr.tf`

Each file is structurally the same, just provision a separate ECR repo for each of the scripts we will be deploying to AWS. I also included a lifecycle policy in each which keeps only the 30 latest images in each repo to reduce cloud storage costs in future when there have been multiple updates down the line. 